### PR TITLE
fix login

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from __future__ import print_function
 
 from ringcentral.http.api_exception import ApiException
 from ringcentral import SDK
@@ -23,12 +24,12 @@ def main():
     # Multipart response
     try:
         multipart_response = platform.get('/account/~/extension/' + user_id + ',' + user_id + '/presence').multipart()
-        print 'Multipart 1\n' + str(multipart_response[0].json_dict())
-        print 'Multipart 2\n' + str(multipart_response[1].json_dict())
+        print('Multipart 1\n' + str(multipart_response[0].json_dict()))
+        print('Multipart 2\n' + str(multipart_response[1].json_dict()))
     except ApiException as e:
-        print 'Cannot load multipart'
-        print 'URL ' + e.api_response().request().url
-        print 'Response' + str(e.api_response().json())
+        print('Cannot load multipart')
+        print('URL ' + e.api_response().request().url)
+        print('Response' + str(e.api_response().json()))
 
 
 if __name__ == '__main__':

--- a/ringcentral/platform/platform.py
+++ b/ringcentral/platform/platform.py
@@ -85,11 +85,12 @@ class Platform(Observable):
                 body = {
                     'grant_type': 'password',
                     'username': username,
-                    'extension': extension,
                     'password': password,
                     'access_token_ttl': ACCESS_TOKEN_TTL,
                     'refresh_token_ttl': REFRESH_TOKEN_TTL
                 }
+                if extension:
+                    body['extension'] = extension
             else:
                 body = {
                     'grant_type': 'authorization_code',


### PR DESCRIPTION
While username is provided as an email address, extension should be omitted, or else following error will throw: 
`{
    "error": "invalid_grant",
    "error_description": "Invalid resource owner credentials",
    "errors": [
        {
            "errorCode": "OAU-140",
            "message": "Invalid resource owner credentials"
        }
    ]
}`