### PR TITLE
Update multipart_builder.py

### DIFF
--- a/ringcentral/http/multipart_builder.py
+++ b/ringcentral/http/multipart_builder.py
@@ -24,7 +24,7 @@ class MultipartBuilder:
     def contents(self):
         return self._contents
 
-    def add(self, attachment):
+    def add(self, attachment, name='attachment'):
         """
         Possible attachment formats:
 
@@ -34,9 +34,10 @@ class MultipartBuilder:
         4. Plain text: ('report.csv', 'some,data,to,send')
 
         :param attachment:
+        :param name='attachment':
         :return:
         """
-        self._contents.append(('attachment', attachment))
+        self._contents.append((name, attachment))
         return self
 
     def request(self, url, method='POST'):


### PR DESCRIPTION
Add the name parameter to the add() method to support APIs that require attachment name.
At least the update user profile API requires the 'image' name in the multipart.