### PR TITLE
Update api_response.py

### DIFF
--- a/ringcentral/http/api_response.py
+++ b/ringcentral/http/api_response.py
@@ -74,7 +74,9 @@ class ApiResponse:
                 message = data['description']
 
         except Exception as e:
-            message = message + ' (and additional error happened during JSON parse: ' + e.message + ')'
+           # message = message + ' (and additional error happened during JSON parse: ' + e.message + ')'
+            message = message + ' (and additional error happened during JSON parse: ' + str(e) + ')'
+
 
         return message
 


### PR DESCRIPTION
Code change from 
            # message = message + ' (and additional error happened during JSON parse: ' + e.message + ')'
 <to>
             message = message + ' (and additional error happened during JSON parse: ' + str(e) + ')'

n Python 3.x and modern versions of Python 2.x use except Exception as e instead of except Exception, e: